### PR TITLE
Draft: File uploads

### DIFF
--- a/src/Actions/StoreAction.php
+++ b/src/Actions/StoreAction.php
@@ -19,7 +19,7 @@ trait StoreAction {
         $this->updateModel($instance, $request);
         $this->validateModel($instance);
 
-        if ($this->viewHasShared('errors')) {
+        if ($this->hasErrors()) {
             return $this->create($request);
         } else {
             $instance->save();

--- a/src/Actions/UpdateAction.php
+++ b/src/Actions/UpdateAction.php
@@ -16,7 +16,7 @@ trait UpdateAction {
         $this->updateModel($instance, $request);
         $this->validateModel($instance);
 
-        if ($this->viewHasShared('errors')) {
+        if ($this->hasErrors()) {
             return $this->edit($request);
         } else {
             $instance->save();

--- a/src/CRUDController.php
+++ b/src/CRUDController.php
@@ -9,6 +9,7 @@ use Cerebralfart\LaravelCRUD\Actions\IndexAction;
 use Cerebralfart\LaravelCRUD\Actions\ShowAction;
 use Cerebralfart\LaravelCRUD\Actions\StoreAction;
 use Cerebralfart\LaravelCRUD\Actions\UpdateAction;
+use Cerebralfart\LaravelCRUD\Contracts\ValidationContract;
 use Cerebralfart\LaravelCRUD\Helpers\AuthHelper;
 use Cerebralfart\LaravelCRUD\Helpers\FilterHelper;
 use Cerebralfart\LaravelCRUD\Helpers\ModelHelper;
@@ -16,10 +17,11 @@ use Cerebralfart\LaravelCRUD\Helpers\OrderHelper;
 use Cerebralfart\LaravelCRUD\Helpers\PropHelper;
 use Cerebralfart\LaravelCRUD\Helpers\RouteHelper;
 use Cerebralfart\LaravelCRUD\Helpers\SearchHelper;
+use Cerebralfart\LaravelCRUD\Helpers\ValidationHelper;
 use Cerebralfart\LaravelCRUD\Helpers\ViewHelper;
 use Illuminate\Routing\Controller;
 
-abstract class CRUDController extends Controller {
+abstract class CRUDController extends Controller implements ValidationContract {
     use CreateAction,
         DestroyAction,
         EditAction,
@@ -34,5 +36,6 @@ abstract class CRUDController extends Controller {
         PropHelper,
         RouteHelper,
         SearchHelper,
+        ValidationHelper,
         ViewHelper;
 }

--- a/src/CRUDController.php
+++ b/src/CRUDController.php
@@ -9,8 +9,10 @@ use Cerebralfart\LaravelCRUD\Actions\IndexAction;
 use Cerebralfart\LaravelCRUD\Actions\ShowAction;
 use Cerebralfart\LaravelCRUD\Actions\StoreAction;
 use Cerebralfart\LaravelCRUD\Actions\UpdateAction;
+use Cerebralfart\LaravelCRUD\Contracts\FileNamingContract;
 use Cerebralfart\LaravelCRUD\Contracts\ValidationContract;
 use Cerebralfart\LaravelCRUD\Helpers\AuthHelper;
+use Cerebralfart\LaravelCRUD\Helpers\FileHelper;
 use Cerebralfart\LaravelCRUD\Helpers\FilterHelper;
 use Cerebralfart\LaravelCRUD\Helpers\ModelHelper;
 use Cerebralfart\LaravelCRUD\Helpers\OrderHelper;
@@ -21,7 +23,7 @@ use Cerebralfart\LaravelCRUD\Helpers\ValidationHelper;
 use Cerebralfart\LaravelCRUD\Helpers\ViewHelper;
 use Illuminate\Routing\Controller;
 
-abstract class CRUDController extends Controller implements ValidationContract {
+abstract class CRUDController extends Controller implements FileNamingContract, ValidationContract {
     use CreateAction,
         DestroyAction,
         EditAction,
@@ -30,6 +32,7 @@ abstract class CRUDController extends Controller implements ValidationContract {
         StoreAction,
         UpdateAction,
         AuthHelper,
+        FileHelper,
         FilterHelper,
         ModelHelper,
         OrderHelper,

--- a/src/Contracts/FileNamingContract.php
+++ b/src/Contracts/FileNamingContract.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Cerebralfart\LaravelCRUD\Contracts;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
+
+interface FileNamingContract {
+    /**
+     * @param Model $model The model to which the file should be associated
+     * @param string $attribute The attribute which the file is associated to
+     * @param UploadedFile $file The file being uploaded
+     * @return string The path to which the file should be saved
+     */
+    function determineFileName(
+        Model        $model,
+        string       $attribute,
+        UploadedFile $file
+    ): string;
+}

--- a/src/Contracts/ValidationContract.php
+++ b/src/Contracts/ValidationContract.php
@@ -7,8 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 interface ValidationContract {
     /**
      * @param Model $model The model to be validated
-     * @param array $rules The developer-defined set of validation rules
-     * @return array The selected subset of validation rules
+     * @param array<string, string> $rules The developer-defined set of validation rules
+     * @return array<string, string> The selected subset of validation rules
      */
     function selectValidationRules(
         Model $model,

--- a/src/Contracts/ValidationContract.php
+++ b/src/Contracts/ValidationContract.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Cerebralfart\LaravelCRUD\Contracts;
+
+use Illuminate\Database\Eloquent\Model;
+
+interface ValidationContract {
+    /**
+     * @param Model $model The model to be validated
+     * @param array $rules The developer-defined set of validation rules
+     * @return array The selected subset of validation rules
+     */
+    function selectValidationRules(
+        Model $model,
+        array $rules,
+    ): array;
+}

--- a/src/Helpers/FileHelper.php
+++ b/src/Helpers/FileHelper.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Cerebralfart\LaravelCRUD\Helpers;
+
+use Cerebralfart\LaravelCRUD\Contracts\FileNamingContract;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+/**
+ * @mixin FileNamingContract
+ */
+trait FileHelper {
+    use ModelHelper, ValidationHelper;
+
+    /** @var array<int, string> */
+    public array $files = [];
+    /** @var array<string, string> */
+    public array $fileValidation = [];
+    /** @var string|null The disk to save the file on, setting to null will use the default disk */
+    public ?string $fileDisk = null;
+    /** @var string|null The folder to save the file in, setting to null will save the file in the root folder */
+    public ?string $fileFolder = null;
+    public array $fileOptions = [];
+
+    protected function updateFiles(Model $model, Request $request): void {
+        $files = array_intersect(array_keys($_FILES), $this->files);
+        foreach ($files as $name) {
+            /** @var UploadedFile|null $file */
+            $file = $request->file($name);
+            $this->updateFile($model, $name, $file);
+        }
+    }
+
+    protected function updateFile(Model $model, string $attribute, ?UploadedFile $file): void {
+        if (!$this->validateFile($attribute, $file)) return;
+
+        if ($file === null) {
+            $this->updateField($model, $attribute, null);
+        } else {
+            $fullPath = $this->normalizeFilePath(
+                $this->fileFolder,
+                $this->determineFileName($model, $attribute, $file)
+            );
+
+            $wasSaved = Storage::disk($this->fileDisk)->putFile($fullPath, $file, $this->fileOptions);
+            if ($wasSaved === false) {
+                $this->addError($attribute, ['File could not be saved']);
+            } else {
+                $this->updateField($model, $attribute, $fullPath);
+            }
+        }
+    }
+
+    protected function validateFile(string $attribute, ?UploadedFile $file): bool {
+        if (array_key_exists($attribute, $this->fileValidation)) {
+            return $this->validate(
+                [$attribute => $file],
+                [$attribute => $this->fileValidation[$attribute]]
+            );
+        }
+        return true;
+    }
+
+    public function determineFileName(Model $model, string $attribute, UploadedFile $file): string {
+        return $file->hashName();
+    }
+
+    protected function normalizeFilePath(?string ...$sections): string {
+        return Str::of(collect($sections)
+            ->filter(fn(?string $val) => $val !== null)
+            ->join('/'))
+            ->replaceMatches('/\/{2,}/', '/')
+            ->ltrim('/');
+    }
+}

--- a/src/Helpers/ModelHelper.php
+++ b/src/Helpers/ModelHelper.php
@@ -14,11 +14,9 @@ use Illuminate\Support\Str;
 /**
  * @property-read class-string<Model> $model
  * @property-read null|string|array<int, string> $modelName
- * @property-read array<string, string> $validationRules
  */
 trait ModelHelper {
     protected $defaultModelName = null;
-    protected array $defaultValidationRules = [];
 
     protected function resolveModelName(Request $request, bool $plural): string {
         if (is_array($this->modelName)) {
@@ -71,18 +69,5 @@ trait ModelHelper {
 
     protected function updateAttribute(Model $model, string $key, mixed $value): void {
         $model->setAttribute($key, $value);
-    }
-
-    protected function validateModel(Model $model): void {
-        $rules = $this->selectValidationRules($model, $this->validationRules);
-        $validator = Validator::make($model->getAttributes(), $rules);
-
-        if ($validator->fails()) {
-            $this->shareToView('errors', $validator->errors());
-        }
-    }
-
-    protected function selectValidationRules(Model $model, array $rules): array {
-        return Arr::only($rules, array_keys($model->getDirty()));
     }
 }

--- a/src/Helpers/ModelHelper.php
+++ b/src/Helpers/ModelHelper.php
@@ -48,6 +48,7 @@ trait ModelHelper {
         foreach ($data as $key => $value) {
             $this->updateField($model, $key, $value);
         }
+        $this->updateFiles($model, $request);
     }
 
     protected function updateField(Model $model, string $key, mixed $value): void {

--- a/src/Helpers/ValidationHelper.php
+++ b/src/Helpers/ValidationHelper.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Cerebralfart\LaravelCRUD\Helpers;
+
+use Illuminate\Contracts\Support\MessageBag;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\MessageBag as MessageBagImpl;
+
+trait ValidationHelper {
+    protected string $sessionErrorKey = 'errors';
+    /** @var array<string, string> */
+    protected array $validationRules = [];
+
+    protected function addError(string $key, array $messages): void {
+        $errors = Session::get($this->sessionErrorKey, []);
+        $errors[$key] = array_merge($errors[$key] ?? [], $messages);
+        Session::flash($this->sessionErrorKey, $errors);
+    }
+
+    protected function addErrors(MessageBag $messages): void {
+        $errors = Session::get($this->sessionErrorKey, []);
+        $errors = array_merge_recursive($errors, $messages->toArray());
+        Session::flash($this->sessionErrorKey, $errors);
+    }
+
+    protected function hasErrors(): bool {
+        return count(Session::get($this->sessionErrorKey, [])) > 0;
+    }
+
+    protected function getErrors(): MessageBag {
+        return new MessageBagImpl(Session::get($this->sessionErrorKey, []));
+    }
+
+    protected function validate(array $data, array $rules): bool {
+        $validator = Validator::make($data, $rules);
+        if ($validator->fails()) {
+            $this->addErrors($validator->getMessageBag());
+            return false;
+        }
+        return true;
+    }
+
+    protected function validateModel(Model $model): bool {
+        return $this->validate(
+            $model->getAttributes(),
+            $this->selectValidationRules($model, $this->validationRules)
+        );
+    }
+
+    public function selectValidationRules(Model $model, array $rules): array {
+        return Arr::only($rules, array_keys($model->getDirty()));
+    }
+}

--- a/src/Helpers/ViewHelper.php
+++ b/src/Helpers/ViewHelper.php
@@ -44,6 +44,9 @@ trait ViewHelper {
     }
 
     protected function view(string $name, array $data = []): View {
+        if ($this->hasErrors()) {
+            ViewFacade::share('errors', $this->getErrors());
+        }
         ViewFacade::share($this->shared);
         $chain = $this->viewMap[$name] ?? static::$defaultViewMap[$name];
         foreach ($chain as $option) {

--- a/src/Strategies/AttributeFolderFileNaming.php
+++ b/src/Strategies/AttributeFolderFileNaming.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Cerebralfart\LaravelCRUD\Strategies;
+
+use Cerebralfart\LaravelCRUD\Contracts\FileNamingContract;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
+
+/**
+ * @mixin FileNamingContract
+ */
+trait AttributeFolderFileNaming {
+    protected function determineFileName(Model $model, string $attribute, UploadedFile $file): string {
+        return sprintf('%s/%s.%s',
+            $attribute,
+            $model->getKey(),
+            $file->extension()
+        );
+    }
+}

--- a/src/Strategies/ModelFolderFileNaming.php
+++ b/src/Strategies/ModelFolderFileNaming.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Cerebralfart\LaravelCRUD\Strategies;
+
+use Cerebralfart\LaravelCRUD\Contracts\FileNamingContract;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
+
+/**
+ * @mixin FileNamingContract
+ */
+trait ModelFolderFileNaming {
+    protected function determineFileName(Model $model, string $attribute, UploadedFile $file): string {
+        return sprintf("%s/%s.%s",
+            $model->getKey(),
+            $attribute,
+            $file->extension()
+        );
+    }
+}

--- a/test/Helpers/FileHelperTest.php
+++ b/test/Helpers/FileHelperTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Cerebralfart\LaravelCRUD\Test\Helpers;
+
+use Cerebralfart\LaravelCRUD\Helpers\FileHelper;
+use Cerebralfart\LaravelCRUD\Test\Mocks\Pokemon;
+use Cerebralfart\LaravelCRUD\Test\TestCase;
+use Illuminate\Http\Testing\File;
+use Illuminate\Support\Facades\Session;
+
+class FileHelperTest extends TestCase {
+    use FileHelper;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->fileValidation = [];
+    }
+
+    public function test_update_file() {
+        $this->fileValidation = ['image' => 'image'];
+        $model = new Pokemon();
+        $model->setAttribute('image', 'old-image.jpg');
+        $this->updateFile($model, 'image', File::image('image.jpg'));
+        $this->assertNotEquals('old-image.jpg', $model->getAttribute('image'));
+        $this->assertEmpty(Session::get('errors'));
+    }
+
+    public function test_update_file_null() {
+        $model = new Pokemon();
+        $model->setAttribute('image', 'old-image.jpg');
+        $this->updateFile($model, 'image', null);
+        $this->assertNull($model->getAttribute('image'));
+    }
+
+    public function test_update_file_invalid() {
+        $this->fileValidation = ['image' => 'image'];
+        $model = new Pokemon();
+        $model->setAttribute('image', 'old-image.jpg');
+        $this->updateFile($model, 'image', File::create('document.txt'));
+        $this->assertEquals('old-image.jpg', $model->getAttribute('image'));
+        $this->assertEquals(['image' => ['The image must be an image.']], Session::get('errors'));
+    }
+
+    public function test_validate_file() {
+        $this->fileValidation = ['file' => 'required|image'];
+        $this->assertFalse($this->validateFile('file', File::create('document.txt')));
+        $this->assertTrue($this->validateFile('file', File::image('image.jpg')));
+    }
+
+    public function test_normalize_file_path() {
+        $this->assertEquals($this->normalizeFilePath('file.jpg'), 'file.jpg');
+        $this->assertEquals($this->normalizeFilePath('/file.jpg'), 'file.jpg');
+        $this->assertEquals($this->normalizeFilePath(null, 'file.jpg'), 'file.jpg');
+        $this->assertEquals($this->normalizeFilePath('folder', 'file.jpg'), 'folder/file.jpg');
+        $this->assertEquals($this->normalizeFilePath('folder', null, 'file.jpg'), 'folder/file.jpg');
+    }
+}

--- a/test/Helpers/ValidationHelperTest.php
+++ b/test/Helpers/ValidationHelperTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Cerebralfart\LaravelCRUD\Test\Helpers;
+
+use Cerebralfart\LaravelCRUD\Helpers\ValidationHelper;
+use Cerebralfart\LaravelCRUD\Test\TestCase;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\MessageBag;
+
+class ValidationHelperTest extends TestCase {
+    use ValidationHelper;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Session::flush();
+    }
+
+    public function test_add_error() {
+        $this->addError('field', ['an error']);
+        $errors = Session::get('errors');
+        $this->assertEquals($errors, ['field' => ['an error']]);
+    }
+
+    public function test_add_error_multiple() {
+        $this->addError('field1', ['one error']);
+        $this->addError('field1', ['another error']);
+        $this->addError('field2', ['totally separate field']);
+        $errors = Session::get('errors');
+        $this->assertEquals($errors, ['field1' => ['one error', 'another error'], 'field2' => ['totally separate field']]);
+    }
+
+    public function test_add_errors() {
+        $this->addErrors(new MessageBag([
+            'field1' => ['one error'],
+            'field2' => ['totally separate field'],
+        ]));
+        $errors = Session::get('errors');
+        $this->assertEquals($errors, ['field1' => ['one error'], 'field2' => ['totally separate field']]);
+    }
+
+    public function test_add_errors_argument_isolation() {
+        $bag = new MessageBag();
+        $this->addErrors($bag);
+        $this->addError('field', ['test']);
+        $this->assertEmpty($bag);
+    }
+
+    public function test_has_error() {
+        $this->assertFalse($this->hasErrors());
+        $this->addError('field', ['an error']);
+        $this->assertTrue($this->hasErrors());
+        Session::flush();
+        $this->assertFalse($this->hasErrors());
+        Session::put('errors', []);
+        $this->assertFalse($this->hasErrors());
+    }
+
+    public function test_get_errors() {
+        $this->assertEmpty($this->getErrors());
+        $this->addError('field', ['one error']);
+        $this->assertInstanceOf(MessageBag::class, $this->getErrors());
+        $this->assertEquals($this->getErrors()->toArray(), ['field' => ['one error']]);
+        $this->addError('field', ['another error']);
+        $this->assertEquals($this->getErrors()->toArray(), ['field' => ['one error', 'another error']]);
+    }
+
+    public function test_validate() {
+        $this->assertFalse($this->validate(
+            ['field' => 'not-an-url'],
+            ['field' => 'url']
+        ));
+        $this->assertTrue($this->hasErrors());
+        $this->assertEquals($this->getErrors()->toArray(), ['field' => ['The field must be a valid URL.']]);
+    }
+
+    public function test_validate_successful() {
+        $this->assertTrue($this->validate(
+            ['field' => 'http://github.com'],
+            ['field' => 'url']
+        ));
+        $this->assertFalse($this->hasErrors());
+        $this->assertEmpty($this->getErrors());
+    }
+
+    public function test_validate_multiple() {
+        $this->validate(
+            ['field1' => 'not-an-url'],
+            ['field1' => 'url']
+        );
+        $this->validate(
+            ['field2' => 'non-numeric'],
+            ['field2' => 'integer']
+        );
+        $this->assertTrue($this->hasErrors());
+        $this->assertEquals($this->getErrors()->toArray(), [
+            'field1' => ['The field1 must be a valid URL.'],
+            'field2' => ['The field2 must be an integer.'],
+        ]);
+    }
+}

--- a/test/Mocks/Controller.php
+++ b/test/Mocks/Controller.php
@@ -12,7 +12,7 @@ class Controller extends CRUDController {
     public $searchColumns = ['name'];
     public $searchMode = 'LIKE'; // TODO sqlite doesn't seem to support ILIKE
 
-    public $validationRules = [
+    public array $validationRules = [
         'name' => 'required|min:3'
     ];
 

--- a/test/Mocks/Pokemon.php
+++ b/test/Mocks/Pokemon.php
@@ -9,9 +9,10 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $name
  * @property float $weight
  * @property float $height
+ * @property string|null $image;
  */
 class Pokemon extends Model {
     public $timestamps = false;
     protected $attributes = ['id' => 0]; // TODO why is this weird SQLite fix neccessary?
-    protected $fillable = ['name', 'weight', 'height'];
+    protected $fillable = ['name', 'weight', 'height', 'image'];
 }


### PR DESCRIPTION
TODO: 

- [ ] File uploads
- [ ] File validation
- [ ] File arrays
---
Addresses #14

### File naming
In trial-implementations, we discussed three different naming strategies and found there is no single best implementation here. The options we discussed are:
- `$folder/$hashName.$extension`: `images/deadbeefcafe.jpg`
- `$folder/$modelKey/$attribute.$extension`: `companies/1/logo.png`
- `$folder/$attribute/$modelKey.$extension`: `companies/logo/1.png`

The first option should be implemented as a default, while the other two should be available as traits to enable them with a single `use`-statement.