### PR TITLE
Share errors to view

### DIFF
--- a/src/Actions/StoreAction.php
+++ b/src/Actions/StoreAction.php
@@ -17,10 +17,9 @@ trait StoreAction {
         $query = $this->model::query();
         $instance = $query->newModelInstance();
         $this->updateModel($instance, $request);
+        $this->validateModel($instance);
 
-        $errors = $this->validateModel($instance);
-        if ($errors) {
-            $this->exposeToView('errors', $errors);
+        if ($this->viewHasShared('errors')) {
             return $this->create($request);
         } else {
             $instance->save();

--- a/src/Actions/UpdateAction.php
+++ b/src/Actions/UpdateAction.php
@@ -14,10 +14,9 @@ trait UpdateAction {
         $instance = $this->resolveModel($request);
         $this->authorize('update', $instance);
         $this->updateModel($instance, $request);
+        $this->validateModel($instance);
 
-        $errors = $this->validateModel($instance);
-        if ($errors) {
-            $this->exposeToView('errors', $errors);
+        if ($this->viewHasShared('errors')) {
             return $this->edit($request);
         } else {
             $instance->save();

--- a/src/Helpers/ModelHelper.php
+++ b/src/Helpers/ModelHelper.php
@@ -73,12 +73,13 @@ trait ModelHelper {
         $model->setAttribute($key, $value);
     }
 
-    protected function validateModel(Model $model): ?MessageBag {
+    protected function validateModel(Model $model): void {
         $rules = $this->selectValidationRules($model, $this->validationRules);
         $validator = Validator::make($model->getAttributes(), $rules);
-        return $validator->fails()
-            ? $validator->errors()
-            : null;
+
+        if ($validator->fails()) {
+            $this->shareToView('errors', $validator->errors());
+        }
     }
 
     protected function selectValidationRules(Model $model, array $rules): array {


### PR DESCRIPTION
Previously, the errors were only available to the top-level template. Now they are available everywhere. This also enables simpler model validation, and later file validation.